### PR TITLE
Make comments stored in datastore 

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -28,6 +28,11 @@
       <artifactId>gson</artifactId>
       <version>2.8.6</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -14,6 +14,12 @@
 
 package com.google.sps.servlets;
 
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -27,18 +33,22 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
-  private List<String> testComments;
-
-  @Override
-  public void init() {
-    testComments = new ArrayList<>();
-  }
-
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    // get all comments by timestamp to keep order of submission
+    Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    PreparedQuery results = datastore.prepare(query);
+
+    List<String> comments = new ArrayList<>();
+    for (Entity commentEntity : results.asIterable()) {
+      String comment = (String) commentEntity.getProperty("text");
+      comments.add(comment);
+    }
+
     // Convert the test comments to JSON
     Gson gson = new Gson();
-    String json = gson.toJson(testComments);
+    String json = gson.toJson(comments);
 
     // Respond with our test comments
     response.setContentType("application/json;");
@@ -48,7 +58,17 @@ public class DataServlet extends HttpServlet {
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String comment = request.getParameter("comment");
-    testComments.add(comment);
+    
+    // time used to guarentee order of comments
+    long timestamp = System.currentTimeMillis();
+
+    Entity commentEntity = new Entity("Comment");
+    commentEntity.setProperty("text", comment);
+    commentEntity.setProperty("timestamp", timestamp);
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    datastore.put(commentEntity);
+
     response.sendRedirect("/index.html");
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -46,11 +46,11 @@ public class DataServlet extends HttpServlet {
       comments.add(comment);
     }
 
-    // Convert the test comments to JSON
+    // Convert the comments to JSON
     Gson gson = new Gson();
     String json = gson.toJson(comments);
 
-    // Respond with our test comments
+    // Respond with our comments
     response.setContentType("application/json;");
     response.getWriter().println(json);
   }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -29,7 +29,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** Servlet that saves and returns comments*/
+/** Servlet that saves and returns comments */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -59,7 +59,7 @@ public class DataServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String comment = request.getParameter("comment");
     
-    // Time used to guarentee order of comments
+    // Time used to guarantee order of comments
     long timestamp = System.currentTimeMillis();
 
     Entity commentEntity = new Entity("Comment");

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -35,7 +35,7 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    // get all comments by timestamp to keep order of submission
+    // Get all comments by timestamp to keep order of submission
     Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
@@ -59,7 +59,7 @@ public class DataServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String comment = request.getParameter("comment");
     
-    // time used to guarentee order of comments
+    // Time used to guarentee order of comments
     long timestamp = System.currentTimeMillis();
 
     Entity commentEntity = new Entity("Comment");
@@ -69,6 +69,7 @@ public class DataServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     datastore.put(commentEntity);
 
+    // Redirect user in order to leave the /data page
     response.sendRedirect("/index.html");
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -36,6 +36,7 @@ public class DataServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     // Get all comments by timestamp to keep order of submission
+    // Sorted newest first so new conversation is not buried under older posts
     Query query = new Query("Comment").addSort("timestamp", SortDirection.DESCENDING);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -29,7 +29,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** Servlet that returns some example content. TODO: modify this file to handle comments data */
+/** Servlet that saves and returns comments*/
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 


### PR DESCRIPTION
Comments from users are now stored in Datastore and are persistent upon server restart. Per Keaton's feedback I've decreased the "what" in my (code) comments and tried to increase the "why", I would like to know how these comments can be improved (more or less sparse? more or less descriptive?).

Images of (user) comments on page and (user) comments in Datastore admin panel.
![index_datastore_comments](https://user-images.githubusercontent.com/65669542/83531444-9b02b000-a4b2-11ea-80e9-9132ab4beca0.png)
![datastore_comments](https://user-images.githubusercontent.com/65669542/83531457-9e963700-a4b2-11ea-8591-8ca7b51b0499.png)
